### PR TITLE
replace singularity container with a Python virtual environment

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -61,18 +61,16 @@ python run_sim.py -h
 ```
 
 
-## Build the Singularity image
+## Build the Python virtual environment
 
-The Singularity image has to be built on a computer where you have admin rights, as root access is needed.
-
-Install [Singularity](https://sylabs.io/singularity/) then create the container using:
+The virtual environment is shared between users of the project and need to be
+created only once:
 ```
-sudo singularity build blender.sif blender
+module purge
+module load BlenderPy/.2.93.1-gimkl-2020a-Python-3.9.5
+VENV_PATH="/nesi/project/nesi00119/mini-gland-synth-venv"
+python3 -m venv --system-site-packages "$VENV_PATH"
+source "${VENV_PATH}/bin/activate"
+pip install pyvista tifffile
+deactivate
 ```
-This will download and compile Blender and all its dependencies to create a Python module.
-
-Once it is finished, you should obtain a `blender.sif` file that you can upload on NeSI.
-
-Don't forget to update the path to this image in your sbatch scripts.
-
-*Note: at the time of writing (2021/04/29), building the image take 1h20min on a 8 cores / 2GHz laptop.*

--- a/cluster/run_default.sl
+++ b/cluster/run_default.sl
@@ -9,15 +9,15 @@ echo "task array id: $SLURM_ARRAY_TASK_ID"
 
 # load environment modules
 ml purge 2> /dev/null
-ml Singularity/3.7.1
+ml BlenderPy/.2.93.1-gimkl-2020a-Python-3.9.5
+
+# activate the virtual environment
+VENV_PATH=/nesi/project/nesi00119/mini-gland-synth-venv
+source ${VENV_PATH}/bin/activate
 
 # directory associated with job array
 job_dir=$( head -n $SLURM_ARRAY_TASK_ID dirs.txt | tail -1 )
 echo "job dir: $job_dir"
 cd $job_dir
 
-# use blender module to create meshes
-BLENDER_IMG=/nesi/project/nesi00119/containers/blender_build_20210429.sif
-
-echo "launching singularity container..."
-singularity exec -B $PWD "$BLENDER_IMG" python3 _create_mini_gland.py
+python3 _create_mini_gland.py

--- a/run/_create_mini_gland.py
+++ b/run/_create_mini_gland.py
@@ -30,12 +30,12 @@ start = time.time()
 # use blender module to create meshes
 print("creating striated duct meshes...")
 sys_call("rm -f Cell*.ply")
-sys_call("python3.9 _mini_gland_striated_duct.py")
+sys_call("python3 _mini_gland_striated_duct.py")
 
 #-----------------------------
 # combine multiple ply files into a single ply file (ply -> ply)
 print("combining ply files...")
-sys_call("python3.8 _ply2ply.py")
+sys_call("python3 _ply2ply.py")
 #sys_call("rm -f Cell_*.ply")
 
 #-----------------------------


### PR DESCRIPTION
This pull request replaces the Singularity container with a Python virtual environment, relying on the new blender-as-a-python package NeSI module (hidden for now).

The virtual shared environment has already been created in the /nesi/project/nesi00119/mini-gland-synth-venv folder.